### PR TITLE
fixing marshal objects of observeddata

### DIFF
--- a/objects/observeddata/observedData.go
+++ b/objects/observeddata/observedData.go
@@ -6,6 +6,8 @@
 package observeddata
 
 import (
+	"encoding/json"
+
 	"github.com/freetaxii/libstix2/objects/baseobject"
 	"github.com/freetaxii/libstix2/timestamp"
 )
@@ -57,10 +59,10 @@ seen that suggested that a particular instance of malware was active).
 */
 type ObservedData struct {
 	baseobject.CommonObjectProperties
-	FirstObserved  string `json:"first_observed,omitempty"`
-	LastObserved   string `json:"last_observed,omitempty"`
-	NumberObserved int    `json:"number_observed,omitempty"`
-	Objects        string `json:"objects,omitempty"`
+	FirstObserved  string           `json:"first_observed,omitempty"`
+	LastObserved   string           `json:"last_observed,omitempty"`
+	NumberObserved int              `json:"number_observed,omitempty"`
+	Objects        *json.RawMessage `json:"objects,omitempty"`
 }
 
 // ----------------------------------------------------------------------
@@ -137,6 +139,7 @@ SetObjects - This takes in a string value that represents represents a cyber
 observable JSON object and updates the objects property.
 */
 func (o *ObservedData) SetObjects(s string) error {
-	o.Objects = s
+	raw := json.RawMessage(s)
+	o.Objects = &raw
 	return nil
 }


### PR DESCRIPTION
Hi, I'm Mayo. I'd like to say thank you for your libstix2 library.
I found an unexpected result in marshaling an observe data like bellow.

```go
package main

import (
	"encoding/json"
	"fmt"

	"github.com/mayoyamasaki/libstix2/objects/bundle"
	"github.com/mayoyamasaki/libstix2/objects/observeddata"
)

func main() {
	b := bundle.New()
	sdo := observeddata.New()
	sdo.SetObjects(`{
		"0": {
		  "type": "ipv4-addr",
		  "value": "198.51.100.3"
		}
	  }`)
	b.AddObject(sdo)
	var data []byte
	data, _ = json.MarshalIndent(b, "", "    ")
	fmt.Println(string(data))
}

```

```
$ go run main.go 
{
    "type": "bundle",
    "id": "bundle--08ccb264-19ca-4d9a-82b7-076a56ac971f",
    "objects": [
        {
            "type": "observed-data",
            "spec_version": "2.1",
            "id": "observed-data--e68d068b-258c-497c-bb12-856ab05f5570",
            "created": "2018-09-28T15:15:40.302Z",
            "modified": "2018-09-28T15:15:40.302Z",
            "objects": "{\n\t\t\"0\": {\n\t\t  \"type\": \"ipv4-addr\",\n\t\t  \"value\": \"198.51.100.3\"\n\t\t}\n\t  }"
        }
    ]
}
```

Apparently, OversedData.objects didn't properly marshal. Therefor, I write a tiny patch to fix the problem using [RawMessage](https://golang.org/pkg/encoding/json/#RawMessage).  And I checked my patch is properly working with no API change.

```
$ go run main.go 
{
    "type": "bundle",
    "id": "bundle--3afbc68a-1697-460d-a1e5-6bbf9c121df7",
    "objects": [
        {
            "type": "observed-data",
            "spec_version": "2.1",
            "id": "observed-data--c8a6990b-c43a-42f4-af16-9a36c0dc20c0",
            "created": "2018-09-28T15:16:51.385Z",
            "modified": "2018-09-28T15:16:51.385Z",
            "objects": {
                "0": {
                    "type": "ipv4-addr",
                    "value": "198.51.100.3"
                }
            }
        }
    ]
}
```