### PR TITLE
fix custom object unmarshal error

### DIFF
--- a/objects/json.go
+++ b/objects/json.go
@@ -41,7 +41,7 @@ func DecodeType(data []byte) (string, error) {
 func Decode(data []byte) (*CommonObjectProperties, error) {
 	var o CommonObjectProperties
 
-	err := json.Unmarshal(data, o)
+	err := json.Unmarshal(data, &o)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Added missing '&', without it decoding will fail with _InvalidUnmarshalError_.