### PR TITLE
Fix JSON unmarshalling error (non-pointer objects.CommonObjectProperties)

### DIFF
--- a/objects/json.go
+++ b/objects/json.go
@@ -41,7 +41,7 @@ func DecodeType(data []byte) (string, error) {
 func Decode(data []byte) (*CommonObjectProperties, error) {
 	var o CommonObjectProperties
 
-	err := json.Unmarshal(data, o)
+	err := json.Unmarshal(data, &o)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When unmarshalling a stix bundle that contains a custom type (causing the unmarshaller to hit the default case in [this switch statement](https://github.com/freetaxii/libstix2/blob/f139962e5ec07872987823fdaeea1e89d1885e2d/objects/bundle/json.go#L173)),   the error `json: Unmarshal(non-pointer objects.CommonObjectProperties)` is returned because it's not being unmarshalled into a pointer type.